### PR TITLE
expose Status value constructors

### DIFF
--- a/src/Geocoding.elm
+++ b/src/Geocoding.elm
@@ -15,7 +15,7 @@ module Geocoding
         , withLocationTypes
         , sendReverseRequest
         , GeocodingResult
-        , Status
+        , Status(..)
         , Viewport
         , ApiKey
         , Component(..)


### PR DESCRIPTION
Geocoding.elm exposes `Status` but not its value constructors (`GeocodingOk`, `ZeroResults`, `OverQueryLimit`, etc.)

This means we can't pattern match on the status field of `Geocoding.Response`. We also cannot construct a `Response` for tests.

This PR simply exposes the values - if you have another way you'd prefer to solve this problem I'd be happy to rework this PR.